### PR TITLE
chore: enforce LF line endings on .sh/.py/.yaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+Dockerfile text eol=lf


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Adds .gitattributes pinning LF on shell, Python, YAML, and Dockerfile. Same pattern already on `molecule-ai-workspace-template-claude-code` after the #1933 fix-v1 CRLF cascade (`exec /entrypoint.sh: no such file or directory` took down 14 workspaces because Windows Docker Desktop checked out entrypoint.sh with CRLF, breaking the shebang).

Mechanical change. No behavior impact until a contributor next checks out on Windows.