### PR TITLE
chore(ci): enroll in org-wide secret-scan reusable workflow (Molecule-AI/molecule-core#2109)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,22 @@
+name: Secret scan
+
+# Calls the canonical reusable workflow in molecule-core. Defense
+# against the #2090-class leak (a hosted-agent commit slipping a
+# credential-shaped string into a PR). Pattern set lives in
+# molecule-core so we do not maintain a parallel copy here.
+#
+# Pinned to @staging because that is the active default branch on the
+# upstream repo (main lags behind via the staging-promotion workflow).
+# Updates ride along automatically as the upstream regex set evolves.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, staging, master]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  secret-scan:
+    uses: Molecule-AI/molecule-core/.github/workflows/secret-scan.yml@staging


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

3-line enrollment in the canonical secret-scan workflow shipped in Molecule-AI/molecule-core#2109. Defense against the #2090-class leak (a hosted-agent commit slipping a credential-shaped string into a PR — caught at the PR layer, before merge).

Pattern set lives in molecule-core; updates ride along automatically.

Part of the bulk plugin/template rollout this iter — identical 3-line workflow per repo, no behaviour change for any other CI.