### PR TITLE
migrate: use new_response_message helper (threads task_id/context_id)

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -90,14 +90,14 @@ class CrewAIA2AExecutor(AgentExecutor):
         self._heartbeat = heartbeat
 
     async def execute(self, context, event_queue):
-        from a2a.helpers import new_text_message
+        from molecule_runtime.executor_helpers import new_response_message
         from molecule_runtime.adapters.shared_runtime import extract_history, build_task_text, brief_task, set_current_task
 
         from molecule_runtime.adapters.shared_runtime import extract_message_text
         user_message = extract_message_text(context)
 
         if not user_message:
-            await event_queue.enqueue_event(new_text_message("No message provided"))
+            await event_queue.enqueue_event(new_response_message(context, "No message provided"))
             return
 
         await set_current_task(self._heartbeat, brief_task(user_message))
@@ -138,7 +138,7 @@ class CrewAIA2AExecutor(AgentExecutor):
         finally:
             await set_current_task(self._heartbeat, "")
 
-        await event_queue.enqueue_event(new_text_message(reply))
+        await event_queue.enqueue_event(new_response_message(context, reply))
 
     async def cancel(self, context, event_queue):  # pragma: no cover
         pass


### PR DESCRIPTION
## Summary

Migrate this template's response Message construction from \`a2a.helpers.new_text_message(text)\` to the canonical \`molecule_runtime.executor_helpers.new_response_message(context, text)\` helper added in **molecule-core PR #2271**.

## Why

\`new_text_message\` builds a Message **without** \`task_id\` or \`context_id\`, which the platform's a2a proxy uses to correlate the response with the originating task. Every other adapter omits these fields too — divergence from the runtime's own canonical pattern in \`workspace/a2a_executor.py:466-475\`.

\`new_response_message(context, text)\` reads \`task_id\` and \`context_id\` from the inbound \`RequestContext\` and threads them through, matching the canonical pattern.

## Status

**Draft.** Depends on molecule-core#2271 merging + cascading to PyPI before this CI passes — the helper doesn't exist on the current PyPI runtime yet. Marked draft so it queues for review without blocking CI on a known dependency gap.

## Test plan

- [x] \`python3 -m py_compile\` clean
- [ ] CI boot-smoke gate (will pass once PyPI publishes the runtime that contains \`new_response_message\`)
- [ ] End-to-end: provision a workspace from this template post-cascade, send an A2A message, confirm response carries \`task_id\` / \`context_id\`

## Stack

This is one of 5 sibling PRs migrating templates to the helper. Each is independent; they merge in any order once the dependency lands.

| Template | PR |
|---|---|
| claude-code | this one (or other) |
| gemini-cli | this one (or other) |
| crewai | this one (or other) |
| openclaw | this one (or other) |
| autogen | this one (or other) |

## Linked

- molecule-core#2271 (helper definition + tests; **dependency**)
- a2a-sdk v0→v1 migration thread: gemini-cli #10, crewai #8, openclaw #9, autogen #8 (rename), claude-code #15 (FilePart)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>